### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :edit, :destroy]
-  before_action :find_item, only: [:show, :edit, :update, :destroy]
+  before_action :authenticate_user!, except: [:index, :show]
+  before_action :find_item, except: [:index, :new, :create]
   before_action :baria_item, only: [:edit, :update, :destroy]
 
   def index

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :edit]
-  before_action :find_item, only: [:show, :edit, :update]
-  before_action :baria_item, only: [:edit, :update]
+  before_action :authenticate_user!, only: [:new, :edit, :destroy]
+  before_action :find_item, only: [:show, :edit, :update, :destroy]
+  before_action :baria_item, only: [:edit, :update, :destroy]
 
   def index
     @items = Item.all.order("id DESC").includes(:user)
@@ -31,6 +31,14 @@ class ItemsController < ApplicationController
       redirect_to item_path(@item.id)
     else
       render :edit
+    end
+  end
+
+  def destroy
+    if @item.destroy
+      redirect_to root_path
+    else
+      render :show
     end
   end
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
       <% if @item.user_id == current_user.id %>
         <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
         <p class='or-text'>or</p>
-        <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+        <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
       <% elsif @item.present? %>
         <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
-  resources :items, only: [:index, :new, :create, :show, :edit, :update]
+  resources :items
   root to: "items#index"
 end


### PR DESCRIPTION
# What
・destroyアクションのルーティングの設定
・削除ボタンへのリンクの実装
・destroyアクションの定義

# Why
・自身が出品した商品を削除できる機能を実装するため。

# Gyazo gif
【出品者であれば商品削除ができ、商品削除が成功したらトップページに遷移する】
https://gyazo.com/269d18440f9faf4b821a6b4670d1afa8